### PR TITLE
Initialize project documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, Texsydo
+Copyright (c) 2022–2025, Tobias Briones
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 # DoRep Jekyll
 
+[![Project](https://mathswe-ops-services.tobiasbriones-dev.workers.dev/badge/project/texsydo)](https://tsd.math.software#dorep-jekyll)
+&nbsp;
+[![GitHub Repository](https://img.shields.io/static/v1?label=GITHUB&message=REPOSITORY&labelColor=555&color=0277bd&style=for-the-badge&logo=GITHUB)](https://github.com/texsydo/dorep-jekyll)
+
+[![GitHub Project License](https://img.shields.io/github/license/texsydo/dorep-jekyll.svg?style=flat-square)](https://github.com/texsydo/dorep-jekyll/blob/main/LICENSE)
+
+[![GitHub Release](https://mathswe-ops-services.tobiasbriones-dev.workers.dev/badge/version/github/texsydo/dorep-jekyll)](https://github.com/texsydo/dorep-jekyll/releases/latest)
+
 Documenting representation of textual systems as a Jekyll static website.
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# dorep-jekyll
+<!-- Copyright (c) 2025 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- This file is part of https://github.com/texsydo/dorep-jekyll -->
+
+# DoRep Jekyll
+
 Documenting representation of textual systems as a Jekyll static website.
+
+## Contact
+
+Tobias Briones: [GitHub](https://github.com/tobiasbriones)
+[LinkedIn](https://linkedin.com/in/tobiasbriones)
+
+## About
+
+**DoRep Jekyll**
+
+Documenting representation of textual systems as a Jekyll static website.
+
+Copyright © 2022–2025 Tobias Briones. All rights reserved.
+
+### License
+
+This project is licensed under the
+[BSD-3-Clause License](LICENSE).


### PR DESCRIPTION
It updates the license information according to the copyright years of the code I'm migrating to this repository (from 2022), and fills the standard template in the `README.md` project file.