### PR TITLE
Fix oldest copyright year in project license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022–2025, Tobias Briones
+Copyright (c) 2023–2025, Tobias Briones
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
I double-checked the oldest code in the ongoing migration, which dates back to 2023 and not 2022 (to be pedantic). There were no custom styles and features in MSW articles in 2022, so the copyright year should start from 2023.