### PR TITLE
Migrate MSW Engineer app logic and styles

### DIFF
--- a/jekyll/_sass/carousel.scss
+++ b/jekyll/_sass/carousel.scss
@@ -1,0 +1,168 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+div.carousel-inner {
+  border: 0.0625rem solid #e0e0e0;
+  border-radius: 1rem;
+}
+
+div.carousel {
+  display: flex;
+  align-items: center;
+  margin: auto;
+}
+
+div.carousel-item {
+  overflow: auto;
+}
+
+div.carousel-inner img {
+  width: 100%;
+  margin: auto;
+}
+
+div.carousel.zoom-in img {
+  width: 175%;
+}
+
+div.carousel + h5 {
+  padding: 0.5rem;
+  margin-top: 0;
+  border-radius: 0.5rem;
+  border: 0.0625rem none #e0e0e0;
+  border-bottom-style: solid;
+  font-weight: bold;
+  text-align: center;
+  font-size: 1rem;
+  color: var(--title-text-color);
+}
+
+div.fullscreen-active .carousel-inner {
+  border: none;
+}
+
+div.fullscreen-active .carousel-inner,
+div.fullscreen-active .carousel-item, {
+  width: 100%;
+}
+
+.carousel-indicators {
+  margin-bottom: 0.5rem;
+  border-radius: 1rem;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.carousel-control-next, .carousel-control-prev {
+  height: 80%; // Avoid colliding with bottom controls
+  top: 10%;
+}
+
+.carousel-control-next .icon,
+.carousel-control-prev .icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 50%;
+}
+
+button.fullscreen,
+button.zoom {
+  position: absolute;
+  width: 2rem;
+  height: 2rem;
+  bottom: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: rgba(0, 0, 0, 0.1) none;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 2;
+}
+
+button.fullscreen {
+  right: 0.5rem;
+}
+
+button.zoom {
+  left: 0.5rem;
+}
+
+button.fullscreen:hover,
+button.zoom:hover {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+button.fullscreen > .enter,
+button.zoom > .enter {
+  display: block;
+}
+
+button.zoom > .exit {
+  display: none;
+}
+
+.fullscreen-active > button.fullscreen > .enter {
+  display: none;
+}
+
+button.fullscreen > .exit {
+  display: none;
+}
+
+.carousel.zoom-in button.zoom > .enter {
+  display: none;
+}
+
+.carousel.zoom-in button.zoom > .exit {
+  display: block;
+}
+
+.fullscreen-active > button.fullscreen > .exit {
+  display: block;
+}
+
+button.fullscreen > .material-symbols-rounded,
+button.zoom > .material-symbols-rounded {
+  font-size: 1.25rem;
+  color: white;
+}
+
+@media screen and (min-width: 720px) {
+  div.carousel.portrait {
+    width: 60%;
+  }
+
+  button.fullscreen,
+  button.zoom {
+    bottom: 1rem;
+  }
+
+  button.fullscreen {
+    right: 1rem;
+  }
+
+  button.zoom {
+    left: 1rem;
+  }
+
+  .carousel-indicators {
+    margin-bottom: 1rem;
+  }
+
+  .carousel-control-next .icon,
+  .carousel-control-prev .icon {
+    width: 3rem;
+    height: 3rem;
+  }
+
+  div.fullscreen-active .carousel-control-next .icon,
+  div.fullscreen-active .carousel-control-prev .icon {
+    width: 4rem;
+    height: 4rem;
+  }
+}

--- a/jekyll/_sass/default.scss
+++ b/jekyll/_sass/default.scss
@@ -1,0 +1,30 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+* {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+  font-family: 'Poppins', sans-serif;
+  //color: rgba(0, 0, 0, 0.89);
+}
+
+html {
+  font-size: 16px;
+}
+
+html,
+body {
+  width: 100%;
+  min-width: 320px;
+}
+
+a {
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: none;
+}

--- a/jekyll/_sass/footer.scss
+++ b/jekyll/_sass/footer.scss
@@ -1,0 +1,51 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+
+footer {
+  padding: var(--content-padding);
+  margin-bottom: 64px;
+}
+
+footer h5 {
+  font-size: 1rem;
+}
+
+footer {
+  font-size: 0.875rem;
+}
+
+footer > .nav ul {
+  list-style-type: none;
+}
+
+footer > .nav a {
+  font-weight: bold;
+  color: #37474f;
+}
+
+footer .legal .notice,
+footer .legal .notice p,
+footer .legal .notice a {
+  font-size: 0.625rem;
+}
+
+@media screen and (min-width: 720px) {
+  footer {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  footer {
+    position: absolute;
+    width: 25%;
+    top: 100%;
+    left: 75%;
+    padding: var(--content-padding);
+    margin-bottom: 0;
+  }
+}

--- a/jekyll/_sass/header.scss
+++ b/jekyll/_sass/header.scss
@@ -1,0 +1,55 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+header {
+  position: fixed;
+  width: 100%;
+  height: var(--nav-height);
+  left: 0;
+  top: 0;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 1;
+}
+
+header.show {
+  transform: translateX(0%);
+}
+
+nav {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  background-color: var(--content-background-color);
+}
+
+nav .home {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  border-top-left-radius: 0;
+}
+
+nav .home span {
+  font-size: 2rem;
+  font-weight: bold;
+  color: var(--title-text-color);
+}
+
+nav .home span.material-symbols-rounded {
+  font-size: 2rem;
+  color: var(--accent-color);
+}
+
+@media screen and (min-width: 1280px) {
+  header {
+    z-index: 0;
+  }
+
+  nav .home {
+    width: 25%;
+  }
+}

--- a/jekyll/_sass/main.scss
+++ b/jekyll/_sass/main.scss
@@ -1,0 +1,167 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+@import "default";
+@import "header";
+@import "footer";
+@import "toc";
+@import "snippet";
+@import "carousel";
+@import "menu";
+@import "table";
+@import "social";
+
+:root {
+  --content-background-color: #fff;
+  --title-text-color: #212121;
+  --content-text-color: #424242;
+  --secondary-text-color: #616161;
+  --third-text-color: #757575;
+  --accent-color: #607d8b;
+  --hover-background-color: #f5f5f5;
+  --accent-blue-text-color: #1565c0;
+}
+
+:root {
+  --content-padding: 5%;
+  --nav-height: 4rem;
+}
+
+body {
+  background-color: var(--content-background-color);
+  color: var(--content-text-color);
+}
+
+section.main {
+  position: relative;
+  margin-bottom: 25vh;
+}
+
+article {
+  padding: var(--content-padding);
+}
+
+h1, h2, h3, h4, h5, figcaption {
+  font-weight: bold;
+  color: var(--title-text-color);
+}
+
+h1 {
+  margin-bottom: 1rem;
+}
+
+h2, h3, h4, h5, h6 {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+
+.pr-subtitle {
+  margin-top: -0.75rem;
+  font-size: 0.875rem;
+  color: var(--secondary-text-color);
+}
+
+figcaption {
+  text-align: center;
+}
+
+a {
+  color: var(--accent-blue-text-color);
+}
+
+.footnotes p {
+  color: var(--secondary-text-color);
+}
+
+blockquote {
+  padding: 0 1rem;
+  border-left: 1px solid #e0e0e0;
+}
+
+blockquote p:not(:last-child) {
+  color: var(--third-text-color);
+}
+
+p img,
+figure img,
+figure video {
+  display: block;
+  max-width: 100%;
+  margin: auto;
+  border: 1px solid #e0e0e0;
+  border-radius: 1rem;
+}
+
+video {
+  min-width: 60%;
+}
+
+img ~ figcaption,
+video ~ figcaption,
+div.a16-9 ~ figcaption {
+  border-top: none;
+  border-left: none;
+  border-right: none;
+}
+
+h1 + figure > figcaption {
+  border: none;
+}
+
+figure > div.a16-9 {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 1px solid #e0e0e0;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+figure > div.a16-9 > img {
+  border: none;
+}
+
+.show {
+  opacity: 1;
+}
+
+@media screen and (min-width: 720px) {
+  :root {
+    --content-padding: 4vw;
+  }
+
+  section.main {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media screen and (min-width: 960px) {
+  section.main {
+    width: 70%;
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  :root {
+    --content-padding: 2vw;
+  }
+
+  section.main {
+    width: 40%;
+    margin-top: 4rem;
+    z-index: 3;
+  }
+
+  article {
+    padding-top: 0.125rem;
+  }
+}
+
+@media screen and (min-width: 1920px) {
+  nav a {
+    padding: 0.5rem 2rem;
+  }
+}

--- a/jekyll/_sass/menu.scss
+++ b/jekyll/_sass/menu.scss
@@ -1,0 +1,48 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+footer > nav {
+  position: fixed;
+  width: 100%;
+  height: var(--nav-height);
+  left: 0;
+  bottom: 0;
+  background-color: var(--content-background-color);
+  border-top: 1px solid #e0e0e0;
+  z-index: 2;
+}
+
+.menu-item {
+  width: 20%;
+  padding: 0.5rem;
+  cursor: pointer;
+}
+
+.menu-item > .title {
+  font-size: 0.75rem;
+  text-align: center;
+  color: var(--third-text-color);
+  margin-bottom: 0.25rem;
+}
+
+.menu-item > .icon > span {
+  display: block;
+  font-size: 1.5rem;
+  margin: auto;
+  color: var(--third-text-color);
+  text-align: center;
+}
+
+@media screen and (min-width: 1280px) {
+  footer > nav {
+    width: 30%;
+    left: 0;
+    border-top: none;
+  }
+
+  .menu-item {
+    width: 50%;
+    padding: 0.5rem 4%;
+  }
+}

--- a/jekyll/_sass/snippet.scss
+++ b/jekyll/_sass/snippet.scss
@@ -1,0 +1,141 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+
+pre {
+  background-color: #fafafa !important;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+code {
+  background-color: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 0.25rem;
+  padding: 0 0.25rem;
+  color: inherit;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+pre {
+  margin: 0;
+}
+
+pre code {
+  border: none;
+  border-radius: 0;
+  padding: 0;
+}
+
+div > div.highlight {
+  border: 1px solid #e0e0e0;
+  margin-bottom: 1rem;
+  border-radius: 0.5rem;
+}
+
+.header ~ div > div.highlight {
+  border-radius: 0;
+  margin-bottom: 0;
+  border-top: none;
+  border-bottom: none;
+}
+
+.header ~ .abstract {
+  padding: 1rem;
+  text-align: center;
+  font-weight: lighter;
+  background-color: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-top: none;
+  border-bottom: none;
+}
+
+.header ~ figcaption,
+figure > figcaption {
+  padding: 0.5rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 0 0 0.5rem 0.5rem;
+}
+
+code > span {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+figure > .header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0;
+  margin-bottom: 0;
+  border: 1px solid #e0e0e0;
+  border-radius: 0.5rem 0.5rem 0 0;
+}
+
+figure > .header > .caption {
+  padding: 0.5rem 1rem;
+  flex: 1;
+}
+
+figure > .header > .menu {
+  display: flex;
+  align-self: stretch;
+  gap: 0;
+}
+
+figure > .header > .menu > button {
+  display: flex;
+  padding: 0 1rem;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-top-right-radius: 0.5rem;
+  background: none;
+  cursor: pointer;
+}
+
+figure > .header > .menu > button > .material-symbols-rounded {
+  font-size: 1.25rem;
+  color: var(--content-text-color);
+}
+
+figure > .header > .menu > button:hover {
+  background-color: var(--hover-background-color);
+}
+
+figure > .header > .menu > button > .tooltip {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  padding: 0.5rem 0.75rem;
+  transition: opacity 0.4s;
+  border-radius: 0.5rem 0 0 0.5rem;
+  border: 0.0625rem solid #f0f0f0;
+  background-color: var(--content-background-color);
+  pointer-events: none;
+}
+
+figure > .headerless {
+  position: absolute;
+  width: 100%;
+  top: 0;
+}
+
+figure > .headerless > .caption {
+  height: 1.5rem;
+  box-sizing: content-box;
+}
+
+figure > .headerless > .menu {
+  z-index: 1;
+}
+
+figure > .headerless > .menu > button {
+  border-bottom-left-radius: 0.5rem;
+}
+
+.headerless ~ div > div.highlight {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+  border-top: 1px solid #e0e0e0;
+}

--- a/jekyll/_sass/social.sass
+++ b/jekyll/_sass/social.sass
@@ -1,0 +1,88 @@
+/*! Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+.social
+  .btn
+    padding: 0.125rem 0.5rem
+    margin: 0.25rem
+
+  i, span
+    font-size: 0.75rem
+    color: white !important
+
+  .btn:active
+    border: 1px solid #fafafa
+
+  a:hover
+    text-decoration: none
+
+.btn-twitter
+  background-color: #1DA1F2
+  border-radius: 16px
+
+  &:hover, &:active
+    background-color: #0e81ce !important
+
+.btn-github
+  background-color: #333
+  border-radius: 16px
+
+  &:hover, &:active
+    background-color: #222 !important
+
+.btn-linkedin
+  background-color: #0077B5
+  border-radius: 16px
+
+  &:hover, &:active
+    background-color: #005d8c !important
+
+.btn-mastodon
+  background-color: #6364FF
+  border-radius: 16px
+
+  &:hover, &:active
+    background-color: #563ACC !important
+
+.btn-youtube
+  background-color: #ff0000
+  border-radius: 16px
+
+  &:hover, &:active
+    background-color: #cc0000 !important
+
+.open-gh-btn
+  .btn
+    padding: 0.5rem 1.5rem
+    margin: 0.25rem
+
+  i
+    font-size: 1.25rem
+
+  span
+    font-size: 1.25rem
+    margin-left: 1rem
+
+.subdir-btn
+  .btn
+    padding: 0.5rem 1.5rem
+    background-color: #eeeeee
+
+    &:hover, &:active
+      background-color: #e0e0e0
+
+  a:hover
+    text-decoration: none
+
+  span
+    font-size: 1.25rem
+    margin-left: 1rem
+
+  .btn:active
+    border: 1px solid #fafafa
+
+  img
+    width: 1.75rem
+    height: 1.75rem
+    margin: 0.125rem 0

--- a/jekyll/_sass/table.sass
+++ b/jekyll/_sass/table.sass
@@ -1,0 +1,30 @@
+/*! Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+table
+  width: auto
+  margin: auto
+  border-collapse: separate
+  font-size: 1rem
+  border: 1px solid #e0e0e0
+  border-radius: 0.5rem
+  margin-bottom: 1rem
+
+  th, td
+    padding: 0.5rem 1rem
+    text-align: left
+    border-bottom: 1px solid #e0e0e0
+
+  th
+    font-weight: bold
+
+  tbody tr
+    transition: 200ms all
+
+    &:nth-child(even)
+      background-color: #f5f5f5
+
+    &:hover
+      background-color: #e0e0e0
+      cursor: pointer

--- a/jekyll/_sass/toc.scss
+++ b/jekyll/_sass/toc.scss
@@ -1,0 +1,103 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+nav.toc {
+  position: fixed;
+  display: flex;
+  left: 0;
+  top: var(--nav-height);
+  bottom: var(--nav-height);
+  flex-direction: column;
+  background-color: var(--content-background-color);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 3;
+}
+
+nav.toc.show {
+  transform: translateX(0%);
+}
+
+nav.toc ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+nav.toc .title {
+  font-size: 1.5rem;
+  font-weight: bold;
+  text-align: center;
+}
+
+nav.toc > ul {
+  padding: var(--content-padding);
+  padding-top: 0;
+  flex: 1;
+  overflow: auto;
+}
+
+nav a {
+  display: block;
+  padding: 0.5rem 2rem;
+  font-size: 1rem;
+  border-radius: 1.25rem;
+  color: var(--title-text-color);
+}
+
+nav a:hover {
+  background-color: var(--hover-background-color);
+  color: inherit;
+}
+
+nav.toc a {
+  border: 0.0625rem solid var(--content-background-color);
+}
+
+nav.toc a.selected {
+  font-weight: bold;
+  background-color: var(--hover-background-color);
+}
+
+nav.toc ul ul {
+  padding-left: 1rem;
+}
+
+nav.toc ul ul ul {
+  padding-left: 2rem;
+}
+
+@media screen and (min-width: 720px) {
+  :root {
+    --content-padding: 4vw;
+  }
+
+  nav.toc > ul {
+    width: 60%;
+    margin: auto;
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  nav.toc {
+    width: 25%;
+    z-index: 0;
+  }
+
+  nav a,
+  nav.toc a {
+    padding: 0.5rem 1rem;
+  }
+
+  nav.toc > ul {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width: 2160px) {
+  nav.toc > ul {
+    width: 60%;
+    margin: auto;
+  }
+}

--- a/jekyll/assets/css/styles.scss
+++ b/jekyll/assets/css/styles.scss
@@ -1,0 +1,7 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+---
+---
+@import "main";

--- a/jekyll/assets/js/main.js
+++ b/jekyll/assets/js/main.js
@@ -1,0 +1,392 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/texsydo/dorep-jekyll
+
+document.addEventListener("DOMContentLoaded", initApp);
+
+function initApp() {
+    const nav = document.querySelector("header > nav");
+    const header = document.querySelector("header");
+    const toc = document.querySelector("nav.toc");
+
+    updateFilePath();
+    initHashNav();
+    initMenu();
+    initNav();
+    initFullScreenElements();
+
+    function initHashNav() {
+        document
+            .querySelectorAll("a")
+            .forEach(anchor => {
+                const href = anchor.getAttribute("href");
+
+                if (href.startsWith("#")) {
+                    anchor.addEventListener("click", e => {
+                        e.preventDefault();
+
+                        if (href === "#") {
+                            history.replaceState(
+                                {},
+                                document.title,
+                                window.location.pathname
+                                + window.location.search,
+                            );
+                        }
+                        else {
+                            window.location.hash = href;
+                        }
+                    });
+                }
+            });
+    }
+
+    function initMenu() {
+        const navButton = document.getElementById("nav-item");
+
+        navButton.addEventListener("click", onNavItemClick);
+
+        function onNavItemClick() {
+            if (isNavShowing()) {
+                hideNav();
+            }
+            else {
+                showNav();
+            }
+        }
+    }
+
+    function initNav() {
+        const anchors = document.querySelectorAll("nav.toc a");
+        let mobile = isMobile();
+
+        const updateSelectedAnchor = hash => {
+            anchors.forEach(anchor => {
+                if (anchor.getAttribute("href") === hash) {
+                    anchor.classList.add("selected");
+                    makeAnchorVisibleInNav(anchor);
+                }
+                else {
+                    anchor.classList.remove("selected");
+                }
+            });
+        };
+
+        anchors.forEach(anchor => {
+            anchor.addEventListener("click", event => {
+                event.preventDefault();
+                if (mobile) {
+                    hideNav();
+                }
+                scrollTo(anchor);
+            });
+        });
+        updateSelectedAnchor(window.location.hash);
+
+        if (!mobile) {
+            showNav();
+        }
+
+        window.addEventListener(
+            "hashchange",
+            () => updateSelectedAnchor(window.location.hash),
+        );
+        window.addEventListener("scroll", selectAnchorFromScrollPosition);
+        window.addEventListener("load", scrollToHashHeading);
+        window.addEventListener("resize", () => {
+            const newMobile = isMobile();
+
+            if (newMobile !== mobile) {
+                // Changed from desktop to mobile
+                if (newMobile) {
+                    hideNav();
+                }
+                else {
+                    showNav();
+                }
+                mobile = newMobile;
+            }
+        });
+
+        function makeAnchorVisibleInNav(anchor) {
+            const anchorRect = anchor.getBoundingClientRect();
+            const navRect = nav.getBoundingClientRect();
+
+            if (anchorRect.top
+                < navRect.top
+                || anchorRect.bottom
+                > navRect.bottom) {
+                nav.scrollTo({
+                    top: anchorRect.top + navRect.height / 2,
+                    behavior: "smooth",
+                });
+            }
+        }
+
+        function selectAnchorFromScrollPosition() {
+            const focusedHeading = getFocusedHeading();
+            const headingId = focusedHeading.getAttribute("id");
+            const hash = `#${ headingId }`;
+
+            if (headingId) {
+                updateSelectedAnchor(hash);
+            }
+        }
+
+        function scrollToHashHeading() {
+            if (!window.location.hash.startsWith("#")) {
+                return;
+            }
+            const hash = window.location.hash;
+            const heading = document.querySelector(hash);
+            heading.scrollIntoView({
+                behavior: "smooth",
+                block: "start",
+            });
+        }
+    }
+
+    function isNavShowing() {
+        return header.classList.contains("show");
+    }
+
+    function showNav() {
+        header.classList.add("show");
+
+        if (toc) {
+            toc.classList.add("show");
+        }
+    }
+
+    function hideNav() {
+        header.classList.remove("show");
+
+        if (toc) {
+            toc.classList.remove("show");
+        }
+    }
+
+    function isMobile() {
+        return window.innerWidth < 1280;
+    }
+}
+
+function scrollTo(anchor) {
+    if (!anchor.href) {
+        return;
+    }
+    const href = anchor.attributes.href.value;
+    const targetId = href.substring(href.indexOf("#"));
+
+    if (targetId === "#") {
+        document.body.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+        });
+        return;
+    }
+
+    const targetSection = document.querySelector(targetId);
+
+    if (targetSection) {
+        targetSection.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+        });
+    }
+}
+
+function getFocusedHeading() {
+    const headings = selectHeadings();
+    const isVisible = heading => {
+        const rect = heading.getBoundingClientRect();
+        return rect.bottom >= 0 && rect.bottom < window.innerHeight;
+    };
+    const visibleHeadings = [];
+    let invisibleHeadingClosestToTop = headings[0];
+
+    for (let i = 0; i < headings.length; i++) {
+        const heading = headings[i];
+
+        if (isVisible(heading)) {
+            visibleHeadings.push(heading);
+        }
+        // Check for the heading right above the page
+        else {
+            const rect = heading.getBoundingClientRect();
+            const maxRect = invisibleHeadingClosestToTop.getBoundingClientRect();
+
+            if (rect.bottom < 0) {
+                if (rect.bottom > maxRect.bottom) {
+                    invisibleHeadingClosestToTop = heading;
+                }
+            }
+        }
+    }
+
+    // Return the closest heading if none is visible
+    if (visibleHeadings.length === 0) {
+        return invisibleHeadingClosestToTop;
+    }
+
+    // Return the heading in the top 1/3 of the page (normal behavior)
+    for (const heading of visibleHeadings) {
+        const rect = heading.getBoundingClientRect();
+
+        if (rect.top < window.innerHeight / 3) {
+            return heading;
+        }
+    }
+    return invisibleHeadingClosestToTop;
+}
+
+function initFullScreenElements() {
+    document
+        .querySelectorAll(".fullscreen")
+        .forEach(fullscreenButton => {
+            const parent = fullscreenButton.parentElement;
+
+            fullscreenButton.addEventListener("click", () => {
+                if (document.fullscreenElement) {
+                    document.exitFullscreen();
+                }
+                else {
+                    goFullscreen(parent);
+                }
+            });
+        });
+
+    document
+        .querySelectorAll(".zoom")
+        .forEach(zoomButton => {
+            const parent = zoomButton.parentElement;
+
+            zoomButton.addEventListener("click", () => {
+                // Apply zoom to all slide images
+                if (parent.classList.contains("zoom-in")) {
+                    parent.classList.remove("zoom-in");
+                }
+                else {
+                    parent.classList.add("zoom-in");
+                }
+            });
+        });
+
+    function goFullscreen(parent) {
+        parent.requestFullscreen();
+        parent.classList.add("fullscreen-active");
+        parent.addEventListener("fullscreenchange", onFullscreenChange);
+
+        window.addEventListener("resize", onResize);
+
+        function onResize() {
+            if (document.fullscreenElement) {
+                setFullscreenDimensions(parent);
+            }
+        }
+
+        function onFullscreenChange() {
+            // Exiting fullscreen
+            if (!document.fullscreenElement) {
+                removeFullscreenDimensions(parent);
+                window.removeEventListener("resize", onResize);
+                parent.removeEventListener(
+                    "fullscreenchange",
+                    onFullscreenChange,
+                );
+            }
+        }
+    }
+
+    function setFullscreenDimensions(parent) {
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+
+        // Apply the scaling transform to all slides
+        parent
+            .querySelectorAll("img")
+            .forEach(img => {
+                const imgWidth = img.width;
+                const imgHeight = img.height;
+                const widthRatio = viewportWidth / imgWidth;
+                // Calculate image size with width=100% to the img as the
+                // baseline
+                const fitImgHeight = imgHeight * widthRatio;
+                const viewportAspectRatio = viewportWidth / viewportHeight;
+                const imgAspectRatio = imgWidth / imgHeight;
+
+                // VP is wider than Image (portrait), fit height
+                if (viewportAspectRatio > imgAspectRatio) {
+                    const scale = viewportHeight / fitImgHeight;
+                    img.style.transform = `scale(${ scale })`;
+                }
+
+                // Else Image (landscape) is wider than VP, fit the width
+                // so width=100% by CSS, and scale=1 by default
+            });
+    }
+
+    function removeFullscreenDimensions(parent) {
+        parent.classList.remove("fullscreen-active");
+        parent
+            .querySelectorAll("img")
+            .forEach(img => {
+                img.style.transform = "none";
+            });
+    }
+}
+
+function onCopyCodeSnippet(button) {
+    const code = button.getAttribute("data-code");
+    const tooltip = button.querySelector(".tooltip");
+
+    navigator
+        .clipboard
+        .writeText(code)
+        .then(() => {
+            tooltip.classList.add("show");
+
+            setTimeout(() => tooltip.classList.remove("show"), 2000);
+        })
+        .catch((reason) => console.log(`Failed to copy code to clipboard: ${ reason }`));
+}
+
+function onOpenCodeSnippetLink(button) {
+    const path = button.getAttribute("data-path");
+    const currentURL = window.location.href.split("#")[0]; // Remove the hash
+                                                           // part if it exists
+    const newURL = currentURL + "/" + path;
+
+    window.open(newURL, "_blank");
+}
+
+function updateFilePath() {
+    if (!pathHasMultipleLevels()) {
+        return;
+    }
+
+    const pageTitle = document.querySelector("h1").textContent;
+
+    // It's a file like DataTest.java
+    // This path update is necessary since Netlify lowercase the path
+    if (pageTitle.includes(".")) {
+        const currentPath = window.location.pathname;
+        const pathSegments = currentPath.split("/");
+
+        pathSegments[pathSegments.length - 1] = pageTitle;
+        const newPath = pathSegments.join("/");
+
+        history.replaceState(null, null, newPath);
+    }
+}
+
+function pathHasMultipleLevels() {
+    const path = window.location.pathname;
+    let segments = path.split("/");
+    segments = segments.filter(segment => segment !== "");
+    return segments.length > 1;
+}
+
+function selectHeadings() {
+    return document.querySelectorAll("h1, h2, h3, h4, h5, h6");
+}


### PR DESCRIPTION
I've developed and designed the JS logic and styles (from my Google MD skillsets) for the MSW Engineer, which still utilizes Jekyll to generate the static site.

They come from the "orphan" prototype I "live" developed in the `ops` branch of the `blog` repository. Then, I migrated the "orphan" prototype to the Texsydo Prototype in `mathswe/prototypes`.

The point is to deprecate Jekyll in favor of React, while keeping the same MSW Engineer results, the logic, and style specifications.

Adding MSW Engineer logic and styles will allow DoRep for Jekyll to build the static sites while migrating to React in the future.